### PR TITLE
removed ANT ifdefs for Android Studio compatibility

### DIFF
--- a/src/net/cooperi/pivapplet/Buffer.java
+++ b/src/net/cooperi/pivapplet/Buffer.java
@@ -12,20 +12,11 @@ import javacard.framework.JCSystem;
 import javacard.framework.SystemException;
 
 public class Buffer {
-#if PIV_SUPPORT_RSA
 	public static final short RAM_ALLOC_SIZE = 512;
 	public static final short RAM_ALLOC_SIZE_2 = 256;
-#else
-	public static final short RAM_ALLOC_SIZE = 256;
-	public static final short RAM_ALLOC_SIZE_2 = 128;
-#endif
 	public static final short EEPROM_ALLOC_SIZE = 1024;
 
-#if APPLET_SIMULATOR
-	public static final short RAM_ALLOC_MAX_INDEX = 2;
-#else
 	public static final short RAM_ALLOC_MAX_INDEX = 8;
-#endif
 
 	public static final byte OFFSET = 0;
 	public static final byte LEN = 1;

--- a/src/net/cooperi/pivapplet/ECParams.java
+++ b/src/net/cooperi/pivapplet/ECParams.java
@@ -13,7 +13,6 @@ import javacard.security.ECKey;
 public class ECParams {
 	public final static byte ALG_ECDSA_SHA_256 = (byte)33;
 
-#if PIV_SUPPORT_EC
 	public static final byte[] nistp256_p = {
 	    (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0x0,
 	    (byte)0x0, (byte)0x0, (byte)0x1, (byte)0x0, (byte)0x0, (byte)0x0,
@@ -81,5 +80,4 @@ public class ECParams {
 		eckey.setR(nistp256_R, (short)0, (short)(nistp256_R.length));
 		//eckey.setK((short)1);
 	}
-#endif
 }


### PR DESCRIPTION
I've integrated PivApplet into a [contactless smart card emulator on Android](http://frankmorgner.github.io/vsmartcard/ACardEmulator/README.html). Basically, I've tied the code to a speciffic configuration, because Android studio doesn't understand ant's ifdefs, afaik. Please comment if you see a better way for integrating the code...