### PR TITLE
Fix ykman reset and AES key support

### DIFF
--- a/src/net/cooperi/pivapplet/PivApplet.java
+++ b/src/net/cooperi/pivapplet/PivApplet.java
@@ -118,7 +118,7 @@ public class PivApplet extends Applet
 	};
 
 	private static final byte[] YKPIV_VERSION = {
-	    (byte)5, (byte)3, (byte)0
+	    (byte)5, (byte)4, (byte)0
 	};
 
 	/* Standard PIV commands we support. */
@@ -432,11 +432,10 @@ public class PivApplet extends Applet
 		slots[SLOT_9B].symAlg = PIV_ALG_3DES;
 /*#else
 		final AESKey ak = (AESKey)KeyBuilder.buildKey(
-		    KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_128, false);
+		    KeyBuilder.TYPE_AES, KeyBuilder.LENGTH_AES_192, false);
 		slots[SLOT_9B].sym = ak;
 		ak.setKey(DEFAULT_ADMIN_KEY, (short)0);
-		slots[SLOT_9B].symAlg = PIV_ALG_AES128;
-		mgmtKeyIsDefault = false;
+		slots[SLOT_9B].symAlg = PIV_ALG_AES192;
 #endif*/
 		/*
 		 * Allow the admin key to be "used" (for auth) without a
@@ -2799,12 +2798,11 @@ public class PivApplet extends Applet
 //#if PIV_SUPPORT_3DES
 		final DESKey dk = (DESKey)slots[SLOT_9B].sym;
 		dk.setKey(DEFAULT_ADMIN_KEY, (short)0);
-		mgmtKeyIsDefault = true;
-//#else
+/*#else
 		final AESKey ak = (AESKey)slots[SLOT_9B].sym;
 		ak.setKey(DEFAULT_ADMIN_KEY, (short)0);
-		mgmtKeyIsDefault = false;
-//#endif
+#endif*/
+		mgmtKeyIsDefault = true;
 
 		pinRetries = (byte)5;
 		pivPin = new OwnerPIN(pinRetries, (byte)8);


### PR DESCRIPTION
When resetting the PIV applet using ykman, the command terminates with an error, because it expects three bytes for the PIN retries.

```
  File "/Applications/YubiKey Manager.app/Contents/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/yubikit/piv.py", line 779, in _get_pin_puk_metadata
    attempts[INDEX_RETRIES_REMAINING],

IndexError: index out of range
```

Looking through the ykman piv code shows the three expected bytes.

```java
    def _get_pin_puk_metadata(self, p2):
        require_version(self.version, (5, 3, 0))
        data = Tlv.parse_dict(self.protocol.send_apdu(0, INS_GET_METADATA, 0, p2))
        pp = pprint.PrettyPrinter(indent=4)
        pp.pprint(data)
        attempts = data[TAG_METADATA_RETRIES]
        return PinMetadata(
            data[TAG_METADATA_IS_DEFAULT] != b"\0",
            attempts[INDEX_RETRIES_TOTAL],
            attempts[INDEX_RETRIES_REMAINING],
        )
```

This patch adds the retries remaining counter.  

Additionally, processReset() failed when DES keys are disabled.  This patch fixes reset when DES keys are disabled.