### PR TITLE
fix bug where responses are truncated under certain circumstances

### DIFF
--- a/src/net/cooperi/pivapplet/SGList.java
+++ b/src/net/cooperi/pivapplet/SGList.java
@@ -362,7 +362,7 @@ public class SGList implements Readable {
 		while (len > 0) {
 			final short take = takeForRead(len);
 			final TransientBuffer buf = buffers[state[RPTR_BUF]];
-			if (take == (short)0)
+			if (take == (short)0 && state[RPTR_BUF] == state[WPTR_BUF])
 				break;
 			dest.append(buf, take);
 			len -= take;


### PR DESCRIPTION
If a SGList has multiple write buffers, SGList#readInto
should iterate through all write buffers and
read the remaining bytes into the destination buffer
until len bytes have been read, or no more bytes remain.
Before this fix, SGList#readInto stopped iterating through the
write buffers at the first write buffer that had no remaining bytes.
However, it can happen that an empty write buffer is between
two write buffers with remaining bytes:

```
WPTR_BUF -> buffer_x   (remaining: 10)
            buffer_x+1 (remaining:  0)
            buffer_x+2 (remaining: 10)
```

In that case, the bytes in buffer_x+2 are not read
and the applet returns a truncated response (e.g. when generating a keypair)